### PR TITLE
Shared parameter ARN output

### DIFF
--- a/modules/shared_parameter_data/README.md
+++ b/modules/shared_parameter_data/README.md
@@ -58,5 +58,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the shared SSM parameter |
 | <a name="output_value"></a> [value](#output\_value) | value - Value of the parameter. This value is always marked as sensitive in the Terraform plan output, regardless of type. In Terraform CLI version 0.15 and later, this may require additional configuration handling for certain scenarios. For more information, see the Terraform v0.15 Upgrade Guide. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/shared_parameter_data/main.tf
+++ b/modules/shared_parameter_data/main.tf
@@ -23,3 +23,8 @@ output "value" {
   description = "value - Value of the parameter. This value is always marked as sensitive in the Terraform plan output, regardless of type. In Terraform CLI version 0.15 and later, this may require additional configuration handling for certain scenarios. For more information, see the Terraform v0.15 Upgrade Guide."
   value       = data.aws_ssm_parameter.this.value
 }
+
+output "arn" {
+  description = "The ARN of the shared SSM parameter"
+  value       = data.aws_ssm_parameter.this.arn
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add ARN output to the `shared_parameter_data` module so users can retrieve the Amazon Resource Name of shared SSM parameters.

---
<p><a href="https://cursor.com/agents/bc-a521af1b-21bc-48a9-8296-ca88f7a5e146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a521af1b-21bc-48a9-8296-ca88f7a5e146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->