### PR TITLE
Add ignore_value_changes support to shared_parameter

### DIFF
--- a/modules/shared_parameter/README.md
+++ b/modules/shared_parameter/README.md
@@ -18,13 +18,49 @@ module "organization_info_shared_parameter" {
   parameter_description    = "Organization information including ARN, root ID, org ID, and account IDs"
   parameter_key_id         = module.default_kms_key_arn.value
   parameter_value          = jsonencode(local.org_info)
-  principals_to_share_with = module.org_entities.created_ous["Security"].arn
+  principals_to_share_with = [module.org_entities.created_ous["Security"].arn]
   tags                     = module.tags.result
 
   providers = {
     aws = aws.primary
   }
 }
+```
+
+### Ignoring later value drift
+Set `ignore_value_changes = true` when Terraform should create the parameter with an initial value, but a human or another system will update the real value in AWS later. Terraform will continue managing the SSM parameter and RAM share, while ignoring later drift in `value`.
+
+```hcl
+module "shared_parameter_with_manual_rotation" {
+  source                   = "../../../../modules/shared_parameter"
+  parameter_name           = "/shared/example/api-token"
+  resource_share_name      = "shared-example-api-token"
+  parameter_description    = "Shared API token placeholder"
+  parameter_key_id         = module.default_kms_key_arn.value
+  parameter_value          = "initial-placeholder"
+  ignore_value_changes     = true
+  principals_to_share_with = [module.org_info.org_arn]
+  tags                     = module.tags.result
+}
+```
+
+AWS SSM Parameter Store requires a non-empty value when the parameter is created. `ignore_value_changes` does not change that requirement. Use a non-empty placeholder `parameter_value` if the real value will be set or rotated later outside Terraform.
+
+If you are enabling `ignore_value_changes` for a parameter that is already in Terraform state, move the state address before planning or applying the toggle:
+
+```bash
+terraform state mv \
+  'module.shared_parameter.aws_ssm_parameter.this[0]' \
+  'module.shared_parameter.aws_ssm_parameter.this_ignore_value[0]'
+```
+
+If you later disable `ignore_value_changes` again for an already-managed parameter, move the state back first:
+
+```bash
+terraform state mv \
+  'module.shared_parameter.aws_ssm_parameter.this_ignore_value[0]' \
+  'module.shared_parameter.aws_ssm_parameter.this[0]'
+```
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -32,14 +68,14 @@ module "organization_info_shared_parameter" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.19.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.40.0 |
 
 ## Modules
 
@@ -52,12 +88,14 @@ module "organization_info_shared_parameter" {
 | Name | Type |
 |------|------|
 | [aws_ssm_parameter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.this_ignore_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_external_principals"></a> [allow\_external\_principals](#input\_allow\_external\_principals) | (Optional) Indicates whether principals outside your organization can be associated with a resource share. | `bool` | `false` | no |
+| <a name="input_ignore_value_changes"></a> [ignore\_value\_changes](#input\_ignore\_value\_changes) | Whether to ignore later out-of-band changes to the parameter value after creation. Enabling this on an already-managed parameter requires a terraform state mv. | `bool` | `false` | no |
 | <a name="input_parameter_description"></a> [parameter\_description](#input\_parameter\_description) | Description of the parameter | `string` | n/a | yes |
 | <a name="input_parameter_key_id"></a> [parameter\_key\_id](#input\_parameter\_key\_id) | The KMS key id or arn for encrypting the parameter | `string` | `null` | no |
 | <a name="input_parameter_name"></a> [parameter\_name](#input\_parameter\_name) | Name of the parameter | `string` | n/a | yes |

--- a/modules/shared_parameter/main.tf
+++ b/modules/shared_parameter/main.tf
@@ -1,4 +1,10 @@
+locals {
+  parameter_arn = var.ignore_value_changes ? aws_ssm_parameter.this_ignore_value[0].arn : aws_ssm_parameter.this[0].arn
+}
+
 resource "aws_ssm_parameter" "this" {
+  count = var.ignore_value_changes ? 0 : 1
+
   name        = var.parameter_name
   description = var.parameter_description
   type        = var.parameter_type
@@ -8,13 +14,34 @@ resource "aws_ssm_parameter" "this" {
   tags        = var.tags
 }
 
+resource "aws_ssm_parameter" "this_ignore_value" {
+  count = var.ignore_value_changes ? 1 : 0
+
+  name        = var.parameter_name
+  description = var.parameter_description
+  type        = var.parameter_type
+  key_id      = var.parameter_key_id
+  tier        = "Advanced"
+  value       = var.parameter_value
+  tags        = var.tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+moved {
+  from = aws_ssm_parameter.this
+  to   = aws_ssm_parameter.this[0]
+}
+
 module "ram_resource_share" {
   source = "../ram_resource_share"
 
   name                      = var.resource_share_name
   allow_external_principals = var.allow_external_principals
 
-  resources  = [aws_ssm_parameter.this.arn]
+  resources  = [local.parameter_arn]
   principals = var.principals_to_share_with
 
   tags = var.tags

--- a/modules/shared_parameter/variables.tf
+++ b/modules/shared_parameter/variables.tf
@@ -14,6 +14,12 @@ variable "parameter_value" {
   type        = string
 }
 
+variable "ignore_value_changes" {
+  description = "Whether to ignore later out-of-band changes to the parameter value after creation. Enabling this on an already-managed parameter requires a terraform state mv."
+  type        = bool
+  default     = false
+}
+
 variable "parameter_description" {
   description = "Description of the parameter"
   type        = string

--- a/modules/shared_parameter/versions.tf
+++ b/modules/shared_parameter/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## Summary

This change adds optional `ignore_value_changes` support to the `shared_parameter` module.

When enabled, Terraform still creates and manages the shared SSM parameter and RAM share, but ignores later out-of-band changes to the parameter `value`. This supports cases where the parameter is created by Terraform and then updated or rotated later by a human or another system.

## Changes

- add `ignore_value_changes` input to `modules/shared_parameter`
- split SSM parameter handling to support `lifecycle.ignore_changes = [value]`
- keep the default upgrade path compatible for existing module users
- document the required `terraform state mv` when toggling `ignore_value_changes` for an already-managed parameter
- fix README examples for `principals_to_share_with`
- keep `modules/default_kms_key_arn/read` on AWS provider `>= 5.0, < 7.0`

## Validation

- `terraform -chdir=modules/shared_parameter init -backend=false`
- `terraform -chdir=modules/shared_parameter validate`
- `terraform -chdir=modules/default_kms_key_arn/read init -backend=false`
- `terraform -chdir=modules/default_kms_key_arn/read validate`

## Notes

Upgrading to this module version without changing inputs should not require any manual action.

Manual state migration is only required if an already-managed parameter later toggles `ignore_value_changes` on or off.
